### PR TITLE
router: add scheme-header-transformation field

### DIFF
--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -652,5 +652,8 @@ message SchemeHeaderTransformation {
   oneof transformation {
     // Overwrite any Scheme header with the contents of this string.
     string scheme_to_overwrite = 1 [(validate.rules).string = {in: "http" in: "https"}];
+
+    // Use the transport protocol to determine the scheme.
+    bool use_transport_scheme = 2;
   }
 }

--- a/api/envoy/extensions/filters/http/router/v3/BUILD
+++ b/api/envoy/extensions/filters/http/router/v3/BUILD
@@ -8,6 +8,7 @@ api_proto_package(
     deps = [
         "//envoy/annotations:pkg",
         "//envoy/config/accesslog/v3:pkg",
+        "//envoy/config/core/v3:pkg",
         "//envoy/extensions/filters/network/http_connection_manager/v3:pkg",
         "@com_github_cncf_xds//udpa/annotations:pkg",
     ],

--- a/api/envoy/extensions/filters/http/router/v3/router.proto
+++ b/api/envoy/extensions/filters/http/router/v3/router.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.filters.http.router.v3;
 
 import "envoy/config/accesslog/v3/accesslog.proto";
+import "envoy/config/core/v3/protocol.proto";
 import "envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto";
 
 import "google/protobuf/duration.proto";
@@ -134,4 +135,9 @@ message Router {
   // upstream HTTP filters will count as a final response if hedging is configured.
   // [#extension-category: envoy.filters.http.upstream]
   repeated network.http_connection_manager.v3.HttpFilter upstream_http_filters = 8;
+
+  // Allows for explicit transformation of the :scheme header on the request path.
+  // If not set, the scheme set by preceding filters or Envoy's default 
+  // :ref:`scheme  <config_http_conn_man_headers_scheme>` handling applies.
+  config.core.v3.SchemeHeaderTransformation scheme_header_transformation = 10;
 }

--- a/source/common/http/async_client_impl.cc
+++ b/source/common/http/async_client_impl.cc
@@ -25,7 +25,8 @@ AsyncClientImpl::AsyncClientImpl(Upstream::ClusterInfoConstSharedPtr cluster,
       config_(factory_context, http_context.asyncClientStatPrefix(), factory_context.localInfo(),
               *stats_store.rootScope(), cm, factory_context.runtime(),
               factory_context.api().randomGenerator(), std::move(shadow_writer), true, false, false,
-              false, false, false, {}, dispatcher.timeSource(), http_context, router_context),
+              false, false, false, absl::nullopt, false, {}, dispatcher.timeSource(), http_context,
+              router_context),
       dispatcher_(dispatcher) {}
 
 AsyncClientImpl::~AsyncClientImpl() {

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -366,6 +366,12 @@ public:
   virtual const absl::optional<std::string>& schemeToSet() const PURE;
 
   /**
+   * @return bool whether to use the upstream transport factory protocol to determine the scheme
+   * name to write into requests.
+   */
+  virtual bool useTransportScheme() const PURE;
+
+  /**
    * @return ConnectionManagerStats& the stats to write to.
    */
   virtual ConnectionManagerStats& stats() PURE;

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -202,6 +202,13 @@ ConnectionManagerUtility::MutateRequestHeadersResult ConnectionManagerUtility::m
     request_headers.setForwardedProto(config.schemeToSet().value());
   }
 
+  if (config.useTransportScheme()) {
+    const std::string& schemeToSet =
+        connection.ssl() ? Headers::get().SchemeValues.Https : Headers::get().SchemeValues.Http;
+    request_headers.setScheme(schemeToSet);
+    request_headers.setForwardedProto(schemeToSet);
+  }
+
   // If :scheme is not set, sets :scheme based on X-Forwarded-Proto if a valid scheme,
   // else encryption level.
   // X-Forwarded-Proto and :scheme may still differ if different values are sent from downstream.

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -639,6 +639,8 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
     scheme_to_set_ = config.scheme_header_transformation().scheme_to_overwrite();
   }
 
+  use_transport_scheme_ = config.scheme_header_transformation().use_transport_scheme();
+
   if (!config.server_name().empty()) {
     server_name_ = config.server_name();
   } else {

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -202,6 +202,7 @@ public:
     return server_transformation_;
   }
   const absl::optional<std::string>& schemeToSet() const override { return scheme_to_set_; }
+  bool useTransportScheme() const override { return use_transport_scheme_; }
   Http::ConnectionManagerStats& stats() override { return stats_; }
   Http::ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() const override { return use_remote_address_; }
@@ -315,6 +316,7 @@ private:
       HttpConnectionManagerProto::OVERWRITE};
   std::string server_name_;
   absl::optional<std::string> scheme_to_set_;
+  bool use_transport_scheme_;
   Tracing::TracerSharedPtr tracer_{std::make_shared<Tracing::NullTracer>()};
   Http::TracingConnectionManagerConfigPtr tracing_config_;
   absl::optional<std::string> user_agent_;

--- a/source/extensions/health_checkers/grpc/health_checker_impl.cc
+++ b/source/extensions/health_checkers/grpc/health_checker_impl.cc
@@ -222,7 +222,9 @@ void GrpcHealthCheckerImpl::GrpcActiveHealthCheckSession::onInterval() {
       headers_message->headers(),
       // Here there is no downstream connection so scheme will be based on
       // upstream crypto
-      host_->transportSocketFactory().implementsSecureTransport());
+      absl::optional<bool>(true), absl::nullopt,
+      // This argument will get shortcircuited by upstream crypto
+      false);
 
   auto status = request_encoder_->encodeHeaders(headers_message->headers(), false);
   // Encoding will only fail if required headers are missing.

--- a/source/extensions/health_checkers/http/health_checker_impl.cc
+++ b/source/extensions/health_checkers/http/health_checker_impl.cc
@@ -265,7 +265,10 @@ void HttpHealthCheckerImpl::HttpActiveHealthCheckSession::onInterval() {
       *request_headers,
       // Here there is no downstream connection so scheme will be based on
       // upstream crypto
-      host_->transportSocketFactory().implementsSecureTransport());
+      absl::optional<bool>(host_->transportSocketFactory().implementsSecureTransport()),
+      absl::nullopt,
+      // This argument will get shortcircuited by upstream crypto
+      false);
   StreamInfo::StreamInfoImpl stream_info(protocol_, parent_.dispatcher_.timeSource(),
                                          local_connection_info_provider_);
   stream_info.setUpstreamInfo(std::make_shared<StreamInfo::UpstreamInfoImpl>());

--- a/source/server/admin/admin.h
+++ b/source/server/admin/admin.h
@@ -162,6 +162,7 @@ public:
   OptRef<const Router::ScopeKeyBuilder> scopeKeyBuilder() override { return scope_key_builder_; }
   const std::string& serverName() const override { return Http::DefaultServerString::get(); }
   const absl::optional<std::string>& schemeToSet() const override { return scheme_; }
+  bool useTransportScheme() const override { return use_transport_scheme_; }
   HttpConnectionManagerProto::ServerHeaderTransformation
   serverHeaderTransformation() const override {
     return HttpConnectionManagerProto::OVERWRITE;
@@ -493,6 +494,7 @@ private:
   const std::vector<Http::OriginalIPDetectionSharedPtr> detection_extensions_{};
   const std::vector<Http::EarlyHeaderMutationPtr> early_header_mutations_{};
   const absl::optional<std::string> scheme_{};
+  const bool use_transport_scheme_ = false;
   const bool ignore_global_conn_limit_;
   std::unique_ptr<HttpConnectionManagerProto::ProxyStatusConfig> proxy_status_config_;
   const Http::HeaderValidatorFactoryPtr header_validator_factory_;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -185,6 +185,7 @@ public:
     return server_transformation_;
   }
   const absl::optional<std::string>& schemeToSet() const override { return scheme_; }
+  bool useTransportScheme() const override { return use_transport_scheme_; }
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() const override { return use_remote_address_; }
@@ -265,6 +266,7 @@ public:
   HttpConnectionManagerProto::ServerHeaderTransformation server_transformation_{
       HttpConnectionManagerProto::OVERWRITE};
   absl::optional<std::string> scheme_;
+  bool use_transport_scheme_{};
   Stats::IsolatedStoreImpl fake_stats_;
   ConnectionManagerStats stats_;
   ConnectionManagerTracingStats tracing_stats_;

--- a/test/common/http/conn_manager_impl_test_base.h
+++ b/test/common/http/conn_manager_impl_test_base.h
@@ -120,6 +120,7 @@ public:
     return server_transformation_;
   }
   const absl::optional<std::string>& schemeToSet() const override { return scheme_; }
+  bool useTransportScheme() const override { return use_transport_scheme_; }
   ConnectionManagerStats& stats() override { return stats_; }
   ConnectionManagerTracingStats& tracingStats() override { return tracing_stats_; }
   bool useRemoteAddress() const override { return use_remote_address_; }
@@ -235,6 +236,7 @@ public:
   HttpConnectionManagerProto::ServerHeaderTransformation server_transformation_{
       HttpConnectionManagerProto::OVERWRITE};
   absl::optional<std::string> scheme_;
+  bool use_transport_scheme_ = false;
   Network::Address::Ipv4Instance local_address_{"127.0.0.1"};
   bool use_remote_address_{true};
   Http::DefaultInternalAddressConfig internal_address_config_;

--- a/test/common/http/hcm_router_fuzz_test.cc
+++ b/test/common/http/hcm_router_fuzz_test.cc
@@ -445,8 +445,10 @@ public:
             false /*start_child_span*/, true /*suppress_envoy_headers*/,
             false /*respect_expected_rq_timeout*/,
             true /*suppress_grpc_request_failure_code_stats*/,
-            false /*flush_upstream_log_on_upstream_stream*/, std::move(strict_headers_to_check),
-            time_system_.timeSystem(), http_context_, router_context_) {
+            false /*flush_upstream_log_on_upstream_stream*/, absl::nullopt, /*scheme_to_overwrite*/
+            false,                                                          /*use_transport_scheme*/
+            std::move(strict_headers_to_check), time_system_.timeSystem(), http_context_,
+            router_context_) {
     cluster_manager_.createDefaultClusters(*this);
     // Install the `RouterFuzzFilter` here
     ON_CALL(filter_factory_, createFilterChain(_))

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -15,7 +15,8 @@ using testing::StartsWith;
 class RouterTestSuppressEnvoyHeaders : public RouterTestBase {
 public:
   RouterTestSuppressEnvoyHeaders()
-      : RouterTestBase(false, true, false, false, Protobuf::RepeatedPtrField<std::string>{}) {}
+      : RouterTestBase(false, true, false, false, absl::nullopt, false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {}
 };
 
 // We don't get x-envoy-expected-rq-timeout-ms or an indication to insert
@@ -110,7 +111,8 @@ TEST_F(RouterTestSuppressEnvoyHeaders, EnvoyAttemptCountInResponseNotPresent) {
 class WatermarkTest : public RouterTestBase {
 public:
   WatermarkTest()
-      : RouterTestBase(false, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {
+      : RouterTestBase(false, false, false, false, absl::nullopt, false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {
     EXPECT_CALL(callbacks_, activeSpan()).WillRepeatedly(ReturnRef(span_));
   };
 
@@ -397,7 +399,8 @@ TEST_F(WatermarkTest, RetryRequestNotComplete) {
 class RouterTestChildSpan : public RouterTestBase {
 public:
   RouterTestChildSpan()
-      : RouterTestBase(true, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {
+      : RouterTestBase(true, false, false, false, absl::nullopt, false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {
     ON_CALL(callbacks_.stream_info_, upstreamClusterInfo())
         .WillByDefault(Return(absl::make_optional<Upstream::ClusterInfoConstSharedPtr>(
             cm_.thread_local_cluster_.cluster_.info_)));
@@ -658,7 +661,8 @@ TEST_F(RouterTestChildSpan, ResetRetryFlow) {
 class RouterTestNoChildSpan : public RouterTestBase {
 public:
   RouterTestNoChildSpan()
-      : RouterTestBase(false, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {}
+      : RouterTestBase(false, false, false, false, absl::nullopt, false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {}
 };
 
 TEST_F(RouterTestNoChildSpan, BasicFlow) {
@@ -709,7 +713,8 @@ class RouterTestStrictCheckOneHeader : public RouterTestBase,
                                        public testing::WithParamInterface<std::string> {
 public:
   RouterTestStrictCheckOneHeader()
-      : RouterTestBase(false, false, false, false, protobufStrList({GetParam()})){};
+      : RouterTestBase(false, false, false, false, absl::nullopt, false,
+                       protobufStrList({GetParam()})){};
 };
 
 INSTANTIATE_TEST_SUITE_P(StrictHeaderCheck, RouterTestStrictCheckOneHeader,
@@ -759,7 +764,8 @@ class RouterTestStrictCheckSomeHeaders
       public testing::WithParamInterface<std::vector<std::string>> {
 public:
   RouterTestStrictCheckSomeHeaders()
-      : RouterTestBase(false, false, false, false, protobufStrList(GetParam())){};
+      : RouterTestBase(false, false, false, false, absl::nullopt, false,
+                       protobufStrList(GetParam())){};
 };
 
 INSTANTIATE_TEST_SUITE_P(StrictHeaderCheck, RouterTestStrictCheckSomeHeaders,
@@ -792,7 +798,7 @@ class RouterTestStrictCheckAllHeaders
       public testing::WithParamInterface<std::tuple<std::string, std::string>> {
 public:
   RouterTestStrictCheckAllHeaders()
-      : RouterTestBase(false, false, false, false,
+      : RouterTestBase(false, false, false, false, absl::nullopt, false,
                        protobufStrList(SUPPORTED_STRICT_CHECKED_HEADERS)){};
 };
 
@@ -865,7 +871,8 @@ TEST(RouterFilterUtilityTest, StrictCheckValidHeaders) {
 class RouterTestSupressGRPCStatsEnabled : public RouterTestBase {
 public:
   RouterTestSupressGRPCStatsEnabled()
-      : RouterTestBase(false, false, true, false, Protobuf::RepeatedPtrField<std::string>{}) {}
+      : RouterTestBase(false, false, true, false, absl::nullopt, false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {}
 };
 
 TEST_F(RouterTestSupressGRPCStatsEnabled, ExcludeTimeoutHttpStats) {
@@ -927,7 +934,8 @@ TEST_F(RouterTestSupressGRPCStatsEnabled, ExcludeTimeoutHttpStats) {
 class RouterTestSupressGRPCStatsDisabled : public RouterTestBase {
 public:
   RouterTestSupressGRPCStatsDisabled()
-      : RouterTestBase(false, false, false, false, Protobuf::RepeatedPtrField<std::string>{}) {}
+      : RouterTestBase(false, false, false, false, absl::nullopt, false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {}
 };
 
 TEST_F(RouterTestSupressGRPCStatsDisabled, IncludeHttpTimeoutStats) {
@@ -976,6 +984,61 @@ TEST_F(RouterTestSupressGRPCStatsDisabled, IncludeHttpTimeoutStats) {
   EXPECT_EQ(1U,
             cm_.thread_local_cluster_.cluster_.info_->stats_store_.counter("upstream_rq_completed")
                 .value());
+}
+
+class RouterTestSchemeToOverwrite : public RouterTestBase {
+public:
+  RouterTestSchemeToOverwrite()
+      : RouterTestBase(false, true, false, false, absl::optional<std::string>("foo"), false,
+                       Protobuf::RepeatedPtrField<std::string>{}) {}
+};
+
+TEST_F(RouterTestSchemeToOverwrite, OverwriteSchemeExplicitly) {
+  EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, absl::optional<Http::Protocol>(), _));
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _, _))
+      .WillOnce(Return(&cancellable_));
+  expectResponseTimerCreate();
+
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(callbacks_.route_->route_entry_, finalizeRequestHeaders(_, _, false));
+  router_->decodeHeaders(headers, true);
+  EXPECT_EQ(headers.getSchemeValue(), "foo");
+
+  // When the router filter gets reset we should cancel the pool request.
+  EXPECT_CALL(cancellable_, cancel(_));
+  router_->onDestroy();
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
+  EXPECT_EQ(0U,
+            callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
+}
+
+class RouterTestUseTransportScheme : public RouterTestBase {
+public:
+  RouterTestUseTransportScheme()
+      : RouterTestBase(false, true, false, false, absl::nullopt, true,
+                       Protobuf::RepeatedPtrField<std::string>{}) {}
+};
+
+TEST_F(RouterTestUseTransportScheme, OverwriteSchemeWithTransport) {
+  EXPECT_CALL(cm_.thread_local_cluster_, httpConnPool(_, absl::optional<Http::Protocol>(), _));
+  EXPECT_CALL(cm_.thread_local_cluster_.conn_pool_, newStream(_, _, _))
+      .WillOnce(Return(&cancellable_));
+  expectResponseTimerCreate();
+
+  Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  headers.setScheme("https");
+  EXPECT_CALL(callbacks_.route_->route_entry_, finalizeRequestHeaders(_, _, false));
+  router_->decodeHeaders(headers, true);
+  EXPECT_EQ(headers.getSchemeValue(), "http");
+
+  // When the router filter gets reset we should cancel the pool request.
+  EXPECT_CALL(cancellable_, cancel(_));
+  router_->onDestroy();
+  EXPECT_TRUE(verifyHostUpstreamStats(0, 0));
+  EXPECT_EQ(0U,
+            callbacks_.route_->route_entry_.virtual_cluster_.stats().upstream_rq_total_.value());
 }
 
 } // namespace Router

--- a/test/common/router/router_test_base.cc
+++ b/test/common/router/router_test_base.cc
@@ -13,6 +13,8 @@ using ::testing::ReturnRef;
 RouterTestBase::RouterTestBase(bool start_child_span, bool suppress_envoy_headers,
                                bool suppress_grpc_request_failure_code_stats,
                                bool flush_upstream_log_on_upstream_stream,
+                               std::optional<std::string> scheme_to_overwrite,
+                               bool use_transport_scheme,
                                Protobuf::RepeatedPtrField<std::string> strict_headers_to_check)
     : pool_(stats_store_.symbolTable()), http_context_(stats_store_.symbolTable()),
       router_context_(stats_store_.symbolTable()), shadow_writer_(new MockShadowWriter()),
@@ -20,8 +22,8 @@ RouterTestBase::RouterTestBase(bool start_child_span, bool suppress_envoy_header
               *stats_store_.rootScope(), cm_, runtime_, random_, ShadowWriterPtr{shadow_writer_},
               true, start_child_span, suppress_envoy_headers, false,
               suppress_grpc_request_failure_code_stats, flush_upstream_log_on_upstream_stream,
-              std::move(strict_headers_to_check), test_time_.timeSystem(), http_context_,
-              router_context_),
+              scheme_to_overwrite, use_transport_scheme, std::move(strict_headers_to_check),
+              test_time_.timeSystem(), http_context_, router_context_),
       router_(std::make_unique<RouterTestFilter>(config_, config_.default_stats_)) {
   router_->setDecoderFilterCallbacks(callbacks_);
   upstream_locality_.set_zone("to_az");

--- a/test/common/router/router_test_base.h
+++ b/test/common/router/router_test_base.h
@@ -63,6 +63,7 @@ public:
   RouterTestBase(bool start_child_span, bool suppress_envoy_headers,
                  bool suppress_grpc_request_failure_code_stats,
                  bool flush_upstream_log_on_upstream_stream,
+                 absl::optional<std::string> scheme_to_overwrite, bool use_transport_scheme,
                  Protobuf::RepeatedPtrField<std::string> strict_headers_to_check);
 
   void expectResponseTimerCreate();

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -596,6 +596,7 @@ public:
     ON_CALL(*this, preserveExternalRequestId()).WillByDefault(testing::Return(false));
     ON_CALL(*this, alwaysSetRequestIdInResponse()).WillByDefault(testing::Return(false));
     ON_CALL(*this, schemeToSet()).WillByDefault(testing::ReturnRef(scheme_));
+    ON_CALL(*this, useTransportScheme()).WillByDefault(testing::Return(false));
     ON_CALL(*this, addProxyProtocolConnectionState()).WillByDefault(testing::Return(true));
   }
 
@@ -637,6 +638,7 @@ public:
   MOCK_METHOD(HttpConnectionManagerProto::ServerHeaderTransformation, serverHeaderTransformation,
               (), (const));
   MOCK_METHOD(const absl::optional<std::string>&, schemeToSet, (), (const));
+  MOCK_METHOD(bool, useTransportScheme, (), (const));
   MOCK_METHOD(ConnectionManagerStats&, stats, ());
   MOCK_METHOD(ConnectionManagerTracingStats&, tracingStats, ());
   MOCK_METHOD(bool, useRemoteAddress, (), (const));

--- a/test/server/admin/admin_test.cc
+++ b/test/server/admin/admin_test.cc
@@ -54,6 +54,7 @@ TEST_P(AdminInstanceTest, Getters) {
   EXPECT_EQ(nullptr, admin_.tracer());
   EXPECT_FALSE(admin_.streamErrorOnInvalidHttpMessaging());
   EXPECT_FALSE(admin_.schemeToSet().has_value());
+  EXPECT_FALSE(admin_.useTransportScheme());
   EXPECT_EQ(admin_.pathWithEscapedSlashesAction(),
             envoy::extensions::filters::network::http_connection_manager::v3::
                 HttpConnectionManager::KEEP_UNCHANGED);


### PR DESCRIPTION
Commit Message: add scheme-header-transformation field to router config
Additional Description: Use a router config toggle to override the scheme of a request
Risk Level: low
Testing: unit testing
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features: n/a
This, in combination to #1, will help address issue [envoyproxy#33020](https://github.com/envoyproxy/envoy/issues/33020)
Depends on #1 